### PR TITLE
Optimize iterator Vec/SetVec

### DIFF
--- a/pc/iterator.go
+++ b/pc/iterator.go
@@ -98,18 +98,20 @@ func (i *float32Iterator) SetFloat32(v float32) {
 }
 
 func (i *float32Iterator) Vec3() mat.Vec3 {
-	return mat.Vec3{i.data[i.pos], i.data[i.pos+1], i.data[i.pos+2]}
+	var ret mat.Vec3
+	copy(ret[:], i.data[i.pos:i.pos+3])
+	return ret
 }
 
 func (i *float32Iterator) Vec3At(j int) mat.Vec3 {
 	pos := i.pos + i.stride*j
-	return mat.Vec3{i.data[pos], i.data[pos+1], i.data[pos+2]}
+	var ret mat.Vec3
+	copy(ret[:], i.data[pos:pos+3])
+	return ret
 }
 
 func (i *float32Iterator) SetVec3(v mat.Vec3) {
-	i.data[i.pos] = v[0]
-	i.data[i.pos+1] = v[1]
-	i.data[i.pos+2] = v[2]
+	copy(i.data[i.pos:i.pos+3], v[:])
 }
 
 type naiveVec3Iterator [3]Float32Iterator

--- a/pc/iterator_test.go
+++ b/pc/iterator_test.go
@@ -70,6 +70,26 @@ func TestVec3Iterator(t *testing.T) {
 		}
 	})
 
+	t.Run("Vec3At", func(t *testing.T) {
+		it, err := pp.Vec3Iterator()
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectedVecs := []mat.Vec3{
+			{1, 2, 3},
+			{4, 5, 6},
+			{7, 8, 9},
+		}
+		for i, expectedVec := range expectedVecs {
+			if !it.IsValid() {
+				t.Fatalf("Iterator is invalid at position %d", i)
+			}
+			if v := it.Vec3At(i); !v.Equal(expectedVec) {
+				t.Errorf("%d: Expected Vec3: %v, got: %v", i, expectedVec, v)
+			}
+		}
+	})
+
 	pp.PointCloudHeader = PointCloudHeader{
 		Fields: []string{"xyz"},
 		Size:   []int{4},

--- a/pc/iterator_test.go
+++ b/pc/iterator_test.go
@@ -97,5 +97,66 @@ func TestVec3Iterator(t *testing.T) {
 			it.Incr()
 		}
 	})
+}
 
+func BenchmarkFloat32Iterator(b *testing.B) {
+	const num = 1024
+	testCases := map[string]struct {
+		data func() Vec3Iterator
+	}{
+		"binaryIterator": {
+			data: func() Vec3Iterator {
+				data := make([]byte, 3*4*num)
+				return naiveVec3Iterator{
+					&binaryFloat32Iterator{
+						binaryIterator: binaryIterator{
+							data:   data,
+							pos:    0,
+							stride: 3 * 4,
+						},
+					},
+					&binaryFloat32Iterator{
+						binaryIterator: binaryIterator{
+							data:   data,
+							pos:    4,
+							stride: 3 * 4,
+						},
+					},
+					&binaryFloat32Iterator{
+						binaryIterator: binaryIterator{
+							data:   data,
+							pos:    8,
+							stride: 3 * 4,
+						},
+					},
+				}
+			},
+		},
+		"float32Iterator": {
+			data: func() Vec3Iterator {
+				return &float32Iterator{
+					data:   make([]float32, 3*num),
+					pos:    0,
+					stride: 3,
+				}
+			},
+		},
+	}
+	b.Run("Vec3", func(b *testing.B) {
+		for name, tt := range testCases {
+			b.Run(name, func(b *testing.B) {
+				var in, out Vec3Iterator
+				for i := 0; i < b.N; i++ {
+					if i%num == 0 {
+						b.StopTimer()
+						in, out = tt.data(), tt.data()
+						b.StartTimer()
+					}
+					out.SetVec3(in.Vec3())
+					in.Incr()
+					out.Incr()
+				}
+			})
+		}
+	})
 }


### PR DESCRIPTION
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 3950X 16-Core Processor

original: BenchmarkFloat32Iterator/Vec3
  float32Iterator-32  79926466   14.88 ns/op
  binaryIterator-32   26346526   45.54 ns/op

this PR: BenchmarkFloat32Iterator/Vec3
  float32Iterator-32  127507297  9.460 ns/op
  binaryIterator-32   26424267   45.57 ns/op
```