### PR TITLE
Add storage/kdtree

### DIFF
--- a/pc/storage/kdtree/kdtree.go
+++ b/pc/storage/kdtree/kdtree.go
@@ -128,10 +128,10 @@ func newNode(ra pc.Vec3RandomAccessor, indice []int, depth int) *node {
 
 	var left, right *node
 	if mid > 0 {
-		left = newNode(ra, indice[0:mid], depth+1)
+		left = newNode(ra, indice[:mid], depth+1)
 	}
 	if mid+1 < len(indice) {
-		right = newNode(ra, indice[mid+1:len(indice)], depth+1)
+		right = newNode(ra, indice[mid+1:], depth+1)
 	}
 	return &node{
 		children: [2]*node{left, right},

--- a/pc/storage/kdtree/kdtree.go
+++ b/pc/storage/kdtree/kdtree.go
@@ -1,0 +1,184 @@
+package kdtree
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/seqsense/pcgol/mat"
+	"github.com/seqsense/pcgol/pc"
+)
+
+type KDTree struct {
+	root *node
+	ra   pc.Vec3RandomAccessor
+
+	poolNodeArray *sync.Pool
+}
+
+type node struct {
+	children [2]*node
+	id       int
+	dim      int
+}
+
+func New(ra pc.Vec3RandomAccessor) (*KDTree, error) {
+	ids := make([]int, ra.Len())
+	for i := 0; i < ra.Len(); i++ {
+		ids[i] = i
+	}
+	root := newNode(ra, ids, 0)
+	maxDepth := root.maxDepth(0)
+	return &KDTree{
+		root: root,
+		ra:   ra,
+
+		poolNodeArray: &sync.Pool{
+			New: func() interface{} {
+				return make([]*node, 0, maxDepth)
+			},
+		},
+	}, nil
+}
+
+func (k *KDTree) newNodeArray(n0 *node) []*node {
+	nodesBuf := k.poolNodeArray.Get().([]*node)
+	return append(nodesBuf[:0], n0)
+}
+
+func (k *KDTree) Nearest(p mat.Vec3, maxRange float32) (int, float32) {
+	nodesOrig := k.newNodeArray(k.root)
+	defer k.poolNodeArray.Put(nodesOrig)
+
+	nodes := k.searchLeafNode(p, nodesOrig)
+	return k.nearestImpl(p, nodes, maxRange*maxRange)
+}
+
+func (k *KDTree) nearestImpl(p mat.Vec3, nodes []*node, maxRangeSq float32) (int, float32) {
+	i := len(nodes) - 1
+	id := nodes[i].id
+	dsq := (k.ra.Vec3At(id).Sub(p)).NormSq()
+	if dsq > maxRangeSq {
+		id, dsq = -1, maxRangeSq
+	}
+	for j := i - 1; j >= 0; j-- {
+		pivot := k.ra.Vec3At(nodes[j].id)
+		dim := nodes[j].dim
+		fromPivot := p[dim] - pivot[dim]
+		fromPivotSq := fromPivot * fromPivot
+		if fromPivotSq > dsq {
+			continue
+		}
+		dsqPivot := (pivot.Sub(p)).NormSq()
+		if dsqPivot < dsq {
+			id, dsq = nodes[j].id, dsqPivot
+		}
+		var nextNode *node
+		if nodes[j].children[0] == nodes[j+1] {
+			nextNode = nodes[j].children[1]
+		} else {
+			nextNode = nodes[j].children[0]
+		}
+		if nextNode == nil {
+			continue
+		}
+
+		nodesOrig := k.newNodeArray(nextNode)
+		ns := k.searchLeafNode(p, nodesOrig)
+		id2, dsq2 := k.nearestImpl(p, ns, dsq)
+		k.poolNodeArray.Put(nodesOrig)
+		if id2 >= 0 {
+			id, dsq = id2, dsq2
+		}
+	}
+	return id, dsq
+}
+
+func (k *KDTree) searchLeafNode(p mat.Vec3, base []*node) []*node {
+	i := len(base) - 1
+	parent := base[i]
+	pivotVal, val := k.ra.Vec3At(parent.id)[parent.dim], p[parent.dim]
+
+	child0, child1 := parent.children[0], parent.children[1]
+	switch {
+	case child0 == nil && child1 == nil:
+		return base
+	case child0 == nil:
+		base = append(base, child1)
+	case child1 == nil:
+		base = append(base, child0)
+	case pivotVal > val:
+		base = append(base, child0)
+	default:
+		base = append(base, child1)
+	}
+	return k.searchLeafNode(p, base)
+}
+
+func newNode(ra pc.Vec3RandomAccessor, indice []int, depth int) *node {
+	is := &indiceSorter{
+		ra:     ra,
+		indice: indice,
+		dim:    depth % 3,
+	}
+	sort.Sort(is)
+	mid := len(is.indice) / 2
+	med := is.indice[mid]
+
+	var left, right *node
+	if mid > 0 {
+		left = newNode(ra, indice[0:mid], depth+1)
+	}
+	if mid+1 < len(indice) {
+		right = newNode(ra, indice[mid+1:len(indice)], depth+1)
+	}
+	return &node{
+		children: [2]*node{left, right},
+		id:       med,
+		dim:      is.dim,
+	}
+}
+
+func (n *node) String() string {
+	return n.stringImpl(0)
+}
+
+func (n *node) stringImpl(depth int) string {
+	if n == nil {
+		return strings.Repeat(" ", depth) + "nil"
+	}
+	return strings.Repeat(" ", depth) + fmt.Sprintf("%d", n.id) + "\n" +
+		n.children[0].stringImpl(depth+1) + "\n" +
+		n.children[1].stringImpl(depth+1)
+}
+
+func (n *node) maxDepth(depth int) int {
+	if n == nil {
+		return depth
+	}
+	d0 := n.children[0].maxDepth(depth + 1)
+	d1 := n.children[1].maxDepth(depth + 1)
+	if d0 > d1 {
+		return d1
+	}
+	return d0
+}
+
+type indiceSorter struct {
+	ra     pc.Vec3RandomAccessor
+	indice []int
+	dim    int
+}
+
+func (s *indiceSorter) Len() int {
+	return len(s.indice)
+}
+
+func (s *indiceSorter) Less(i, j int) bool {
+	return s.ra.Vec3At(s.indice[i])[s.dim] < s.ra.Vec3At(s.indice[j])[s.dim]
+}
+
+func (s *indiceSorter) Swap(i, j int) {
+	s.indice[i], s.indice[j] = s.indice[j], s.indice[i]
+}

--- a/pc/storage/kdtree/kdtree.go
+++ b/pc/storage/kdtree/kdtree.go
@@ -23,7 +23,7 @@ type node struct {
 	dim      int
 }
 
-func New(ra pc.Vec3RandomAccessor) (*KDTree, error) {
+func New(ra pc.Vec3RandomAccessor) *KDTree {
 	ids := make([]int, ra.Len())
 	for i := 0; i < ra.Len(); i++ {
 		ids[i] = i
@@ -39,7 +39,7 @@ func New(ra pc.Vec3RandomAccessor) (*KDTree, error) {
 				return make([]*node, 0, maxDepth)
 			},
 		},
-	}, nil
+	}
 }
 
 func (k *KDTree) newNodeArray(n0 *node) []*node {

--- a/pc/storage/kdtree/kdtree_test.go
+++ b/pc/storage/kdtree/kdtree_test.go
@@ -1,0 +1,336 @@
+package kdtree
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/seqsense/pcgol/mat"
+	"github.com/seqsense/pcgol/pc"
+	"github.com/seqsense/pcgol/pc/storage"
+)
+
+var _ storage.Search = &KDTree{} // KDTree must implement storage.Search
+
+func TestKDtree(t *testing.T) {
+	pp := &pc.PointCloud{
+		PointCloudHeader: pc.PointCloudHeader{
+			Fields: []string{"x", "y", "z"},
+			Size:   []int{4, 4, 4},
+			Type:   []string{"F", "F", "F"},
+			Count:  []int{1, 1, 1},
+			Width:  7,
+			Height: 1,
+		},
+		Points: 7,
+		Data:   make([]byte, 7*4*3),
+	}
+	it, err := pp.Vec3Iterator()
+	if err != nil {
+		t.Fatal(err)
+	}
+	it.SetVec3(mat.Vec3{4, 1, 0}) // 0
+	it.Incr()
+	it.SetVec3(mat.Vec3{2, 2, 1}) // 1
+	it.Incr()
+	it.SetVec3(mat.Vec3{5, 0, 0}) // 2
+	it.Incr()
+	it.SetVec3(mat.Vec3{3, 0, 0}) // 3
+	it.Incr()
+	it.SetVec3(mat.Vec3{0, 1, 0}) // 4
+	it.Incr()
+	it.SetVec3(mat.Vec3{1, 0, 0}) // 5
+	it.Incr()
+	it.SetVec3(mat.Vec3{6, 2, 1}) // 6
+	it.Incr()
+	//      3
+	//     / \
+	//    /   \
+	//   4     0
+	//  / \   / \
+	// 5   1 2   6
+
+	it, err = pp.Vec3Iterator()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kdt, err := New(it)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedTree := &KDTree{
+		root: &node{
+			children: [2]*node{
+				&node{
+					children: [2]*node{
+						&node{id: 5, dim: 2},
+						&node{id: 1, dim: 2},
+					},
+					id:  4,
+					dim: 1,
+				},
+				&node{
+					children: [2]*node{
+						&node{id: 2, dim: 2},
+						&node{id: 6, dim: 2},
+					},
+					id:  0,
+					dim: 1,
+				},
+			},
+			id:  3,
+			dim: 0,
+		},
+		ra: it,
+	}
+	if !reflect.DeepEqual(expectedTree.root, kdt.root) {
+		t.Fatalf("Expected:\n%s\nGot:\n%s", expectedTree.root, kdt.root)
+	}
+
+	t.Run("SearchNode", func(t *testing.T) {
+		testCases := []struct {
+			p      mat.Vec3
+			nodeID int
+		}{
+			{
+				p:      mat.Vec3{5, 0, 0},
+				nodeID: 2,
+			},
+			{
+				p:      mat.Vec3{2, 2, 1},
+				nodeID: 1,
+			},
+			{
+				p:      mat.Vec3{4, 1, 0},
+				nodeID: 6,
+			},
+		}
+		for _, tt := range testCases {
+			tt := tt
+			t.Run(fmt.Sprintf("(%.0f,%.0f,%.0f)", tt.p[0], tt.p[1], tt.p[2]), func(t *testing.T) {
+				n := kdt.searchLeafNode(tt.p, []*node{kdt.root})
+				if n[len(n)-1].id != tt.nodeID {
+					t.Errorf("Expected node.id: %d, got: %d", tt.nodeID, n[len(n)-1].id)
+				}
+			})
+		}
+	})
+	t.Run("Nearest", func(t *testing.T) {
+		testCases := []struct {
+			p        mat.Vec3
+			nodeID   int
+			distSq   float32
+			maxRange float32
+		}{
+			{
+				p:        mat.Vec3{5, 0, 0},
+				nodeID:   2,
+				distSq:   0,
+				maxRange: 1.0,
+			},
+			{
+				p:        mat.Vec3{5, 0, 0.1},
+				nodeID:   2,
+				distSq:   0.1 * 0.1,
+				maxRange: 1.0,
+			},
+			{
+				p:        mat.Vec3{4.9, 0.0, 0.0},
+				nodeID:   2,
+				distSq:   0.1 * 0.1,
+				maxRange: 1.0,
+			},
+			{
+				p:        mat.Vec3{3, 0, 0},
+				nodeID:   3,
+				distSq:   0,
+				maxRange: 1.0,
+			},
+			{
+				p:        mat.Vec3{3, 0, 0.1},
+				nodeID:   3,
+				distSq:   0.1 * 0.1,
+				maxRange: 1.0,
+			},
+			{
+				p:        mat.Vec3{2.1, 1.9, 1},
+				nodeID:   1,
+				distSq:   2 * 0.1 * 0.1,
+				maxRange: 1.0,
+			},
+			{
+				p:        mat.Vec3{2.1, 2.1, 1},
+				nodeID:   1,
+				distSq:   2 * 0.1 * 0.1,
+				maxRange: 1.0,
+			},
+			{
+				p:        mat.Vec3{3.9, 1, 0},
+				nodeID:   0,
+				distSq:   0.1 * 0.1,
+				maxRange: 1.0,
+			},
+			{
+				p:        mat.Vec3{4.1, 1, 0},
+				nodeID:   0,
+				distSq:   0.1 * 0.1,
+				maxRange: 1.0,
+			},
+			{
+				p:        mat.Vec3{4.2, 1, 0},
+				nodeID:   -1,
+				distSq:   0.1 * 0.1,
+				maxRange: 0.1,
+			},
+		}
+		const eps = 0.00001
+		for _, tt := range testCases {
+			tt := tt
+			t.Run(fmt.Sprintf(
+				"(%.1f,%.1f,%.1f)-%0.1f",
+				tt.p[0], tt.p[1], tt.p[2], tt.maxRange,
+			), func(t *testing.T) {
+				i, dsq := kdt.Nearest(tt.p, tt.maxRange)
+				if i != tt.nodeID {
+					t.Errorf("Expected id: %d, got: %d", tt.nodeID, i)
+				}
+				if dsq < tt.distSq-eps || tt.distSq+eps < dsq {
+					t.Errorf("Expected distance^2: %0.4f, got: %0.4f", tt.distSq, dsq)
+				}
+			})
+		}
+	})
+}
+
+func TestKDtree_randomCloud(t *testing.T) {
+	const (
+		nPoints = 100
+		width   = 10.0
+	)
+
+	pp := generateRandomCloud(t, nPoints, width)
+	it, err := pp.Vec3Iterator()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kdt, err := New(it)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ns := &naiveSearch{it}
+
+	for i := 0; i < nPoints; i++ {
+		p := randomPoint(width)
+		maxRange := rand.Float32() * width
+
+		idNaive, dsqNaive := ns.Nearest(p, maxRange)
+		idKDTree, dsqKDTree := kdt.Nearest(p, maxRange)
+		strNaive := ""
+		if idNaive >= 0 {
+			strNaive = it.Vec3At(idNaive).String()
+		}
+		strKDTree := ""
+		if idKDTree >= 0 {
+			strKDTree = it.Vec3At(idKDTree).String()
+		}
+		if idNaive != idKDTree || dsqNaive != dsqKDTree {
+			t.Fatalf(
+				"%d %0.3f %s: Expected: %d %0.3f %s, got: %d %0.3f %s",
+				i, maxRange, p, idNaive, dsqNaive, strNaive, idKDTree, dsqKDTree, strKDTree,
+			)
+		}
+	}
+}
+
+type naiveSearch struct {
+	ra pc.Vec3RandomAccessor
+}
+
+func (s *naiveSearch) Nearest(p mat.Vec3, maxRange float32) (int, float32) {
+	dsq := maxRange * maxRange
+	id := -1
+	for i := 0; i < s.ra.Len(); i++ {
+		dsq1 := s.ra.Vec3At(i).Sub(p).NormSq()
+		if dsq1 < dsq {
+			id, dsq = i, dsq1
+		}
+	}
+	return id, dsq
+}
+
+func randomPoint(width float32) mat.Vec3 {
+	return mat.Vec3{
+		rand.Float32() * width,
+		rand.Float32() * width,
+		rand.Float32() * width,
+	}
+}
+
+func generateRandomCloud(t testing.TB, nPoints int, width float32) *pc.PointCloud {
+	t.Helper()
+	pp := &pc.PointCloud{
+		PointCloudHeader: pc.PointCloudHeader{
+			Fields: []string{"x", "y", "z"},
+			Size:   []int{4, 4, 4},
+			Type:   []string{"F", "F", "F"},
+			Count:  []int{1, 1, 1},
+			Width:  nPoints,
+			Height: 1,
+		},
+		Points: nPoints,
+		Data:   make([]byte, nPoints*4*3),
+	}
+	it, err := pp.Vec3Iterator()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < nPoints; i++ {
+		it.SetVec3(randomPoint(width))
+		it.Incr()
+	}
+	return pp
+}
+
+func BenchmarkKDTree_Nearest(b *testing.B) {
+	const (
+		width    = 10.0
+		nTargets = 100
+	)
+	for _, nPoints := range []int{100, 1000, 10000, 100000} {
+		b.Run(fmt.Sprintf("%dpoints", nPoints), func(b *testing.B) {
+			pp := generateRandomCloud(b, nPoints, width)
+			targets := generateRandomCloud(b, nTargets, width)
+
+			it, err := pp.Vec3Iterator()
+			if err != nil {
+				b.Fatal(err)
+			}
+			kdt, err := New(it)
+			if err != nil {
+				b.Fatal(err)
+			}
+			ns := &naiveSearch{it}
+
+			itTargets, err := targets.Vec3Iterator()
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.Run("KDTree", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					target := itTargets.Vec3At(i % nTargets)
+					_, _ = kdt.Nearest(target, width)
+				}
+			})
+			b.Run("Naive", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					target := itTargets.Vec3At(i % nTargets)
+					_, _ = ns.Nearest(target, width)
+				}
+			})
+		})
+	}
+}

--- a/pc/storage/kdtree/kdtree_test.go
+++ b/pc/storage/kdtree/kdtree_test.go
@@ -55,10 +55,7 @@ func TestKDtree(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	kdt, err := New(it)
-	if err != nil {
-		t.Fatal(err)
-	}
+	kdt := New(it)
 
 	expectedTree := &KDTree{
 		root: &node{
@@ -215,11 +212,7 @@ func TestKDtree_randomCloud(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	kdt, err := New(it)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	kdt := New(it)
 	ns := &naiveSearch{it}
 
 	for i := 0; i < nPoints; i++ {
@@ -308,10 +301,7 @@ func BenchmarkKDTree_Nearest(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			kdt, err := New(it)
-			if err != nil {
-				b.Fatal(err)
-			}
+			kdt := New(it)
 			ns := &naiveSearch{it}
 
 			itTargets, err := targets.Vec3Iterator()

--- a/pc/storage/kdtree/kdtree_test.go
+++ b/pc/storage/kdtree/kdtree_test.go
@@ -43,7 +43,6 @@ func TestKDtree(t *testing.T) {
 	it.SetVec3(mat.Vec3{1, 0, 0}) // 5
 	it.Incr()
 	it.SetVec3(mat.Vec3{6, 2, 1}) // 6
-	it.Incr()
 	//      3
 	//     / \
 	//    /   \

--- a/pc/storage/search.go
+++ b/pc/storage/search.go
@@ -1,0 +1,9 @@
+package storage
+
+import (
+	"github.com/seqsense/pcgol/mat"
+)
+
+type Search interface {
+	Nearest(p mat.Vec3, maxRange float32) (int, float32)
+}


### PR DESCRIPTION
Planning to use it for ICP registration.
```
goos: linux
goarch: amd64
pkg: github.com/seqsense/pcgol/pc/storage/kdtree
cpu: AMD Ryzen 9 3950X 16-Core Processor       
BenchmarkKDTree_Nearest/100points/KDTree    1675342    715.3 ns/op   201 B/op   5 allocs/op
BenchmarkKDTree_Nearest/100points/Naive     1263472    946.7 ns/op     0 B/op   0 allocs/op
BenchmarkKDTree_Nearest/1000points/KDTree    971581     1207 ns/op   329 B/op   8 allocs/op
BenchmarkKDTree_Nearest/1000points/Naive     131896     8678 ns/op     0 B/op   0 allocs/op
BenchmarkKDTree_Nearest/10000points/KDTree   884264     1319 ns/op   278 B/op   7 allocs/op
BenchmarkKDTree_Nearest/10000points/Naive     14004    85522 ns/op     0 B/op   0 allocs/op
BenchmarkKDTree_Nearest/100000points/KDTree  676402     1746 ns/op   415 B/op   7 allocs/op
BenchmarkKDTree_Nearest/100000points/Naive     1389   859469 ns/op     0 B/op   0 allocs/op
```