### PR TITLE
Fix iterators

### DIFF
--- a/pc/iterator.go
+++ b/pc/iterator.go
@@ -64,7 +64,7 @@ func (i *binaryFloat32Iterator) SetFloat32(v float32) {
 }
 
 func (i *binaryFloat32Iterator) IsValid() bool {
-	return i.pos+4 == len(i.data)
+	return i.pos+4 <= len(i.data)
 }
 
 type float32Iterator struct {

--- a/pc/iterator.go
+++ b/pc/iterator.go
@@ -18,7 +18,7 @@ func (i *binaryIterator) Incr() {
 }
 
 func (i *binaryIterator) IsValid() bool {
-	return i.pos+i.stride <= len(i.data)
+	return i.pos+i.stride <= len(i.data) || i.pos+4 == len(i.data)
 }
 
 func (i *binaryIterator) Len() int {
@@ -78,7 +78,7 @@ func (i *float32Iterator) Incr() {
 }
 
 func (i *float32Iterator) IsValid() bool {
-	return i.pos+i.stride <= len(i.data)
+	return i.pos+i.stride <= len(i.data) || i.pos+1 == len(i.data)
 }
 
 func (i *float32Iterator) Len() int {

--- a/pc/iterator.go
+++ b/pc/iterator.go
@@ -17,10 +17,6 @@ func (i *binaryIterator) Incr() {
 	i.pos += i.stride
 }
 
-func (i *binaryIterator) IsValid() bool {
-	return i.pos+i.stride <= len(i.data) || i.pos+4 == len(i.data)
-}
-
 func (i *binaryIterator) Len() int {
 	return len(i.data) / i.stride
 }
@@ -67,6 +63,10 @@ func (i *binaryFloat32Iterator) SetFloat32(v float32) {
 	)
 }
 
+func (i *binaryFloat32Iterator) IsValid() bool {
+	return i.pos+4 == len(i.data)
+}
+
 type float32Iterator struct {
 	data   []float32
 	pos    int
@@ -78,7 +78,7 @@ func (i *float32Iterator) Incr() {
 }
 
 func (i *float32Iterator) IsValid() bool {
-	return i.pos+i.stride <= len(i.data) || i.pos+1 == len(i.data)
+	return i.pos+1 <= len(i.data)
 }
 
 func (i *float32Iterator) Len() int {
@@ -170,4 +170,8 @@ func (i *binaryUint32Iterator) SetUint32(v uint32) {
 	binary.LittleEndian.PutUint32(
 		i.binaryIterator.data[i.binaryIterator.pos:i.binaryIterator.pos+4], v,
 	)
+}
+
+func (i *binaryUint32Iterator) IsValid() bool {
+	return i.pos+4 <= len(i.data)
 }

--- a/pc/iterator_test.go
+++ b/pc/iterator_test.go
@@ -155,22 +155,6 @@ func TestUint32Iterator(t *testing.T) {
 		t.FailNow()
 	}
 
-	t.Run("Uint32At", func(t *testing.T) {
-		it, err := pp.Uint32Iterator("label")
-		if err != nil {
-			t.Fatal(err)
-		}
-		expectedLabels := []uint32{1, 2, 3}
-		for i, expectedLabel := range expectedLabels {
-			if !it.IsValid() {
-				t.Fatalf("Iterator is invalid at position %d", i)
-			}
-			if v := it.Uint32At(i); v != expectedLabel {
-				t.Errorf("Expected: %v, got: %v", expectedLabel, v)
-			}
-		}
-	})
-
 	t.Run("Uint32", func(t *testing.T) {
 		it, err := pp.Uint32Iterator("label")
 		if err != nil {
@@ -185,6 +169,22 @@ func TestUint32Iterator(t *testing.T) {
 				t.Errorf("Expected: %v, got: %v", expectedLabel, v)
 			}
 			it.Incr()
+		}
+	})
+
+	t.Run("Uint32At", func(t *testing.T) {
+		it, err := pp.Uint32Iterator("label")
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectedLabels := []uint32{1, 2, 3}
+		for i, expectedLabel := range expectedLabels {
+			if !it.IsValid() {
+				t.Fatalf("Iterator is invalid at position %d", i)
+			}
+			if v := it.Uint32At(i); v != expectedLabel {
+				t.Errorf("Expected: %v, got: %v", expectedLabel, v)
+			}
 		}
 	})
 }
@@ -202,7 +202,7 @@ func TestFloat32IteratorAndUint32Iterator(t *testing.T) {
 		Points: 3,
 		Data:   make([]byte, 3*4*2),
 	}
-	if ok := t.Run("SeUint32SetFloat32", func(t *testing.T) {
+	if ok := t.Run("SetFloat32SeUint32", func(t *testing.T) {
 		it, err := pp.Float32Iterator("x")
 		if err != nil {
 			t.Fatal(err)
@@ -285,7 +285,7 @@ func TestFloat32IteratorAndUint32Iterator(t *testing.T) {
 				t.Fatalf("Iterator is invalid at position %d", i)
 			}
 			if v := it.Float32At(i); v != expectedX {
-				t.Errorf("Expected Vec3: %v, got: %v", expectedX, v)
+				t.Errorf("Expected: %v, got: %v", expectedX, v)
 			}
 		}
 
@@ -296,6 +296,116 @@ func TestFloat32IteratorAndUint32Iterator(t *testing.T) {
 			}
 			if v := lt.Uint32At(i); v != expectedLabel {
 				t.Errorf("Expected: %v, got: %v", expectedLabel, v)
+			}
+		}
+	})
+}
+
+func TestUint32IteratorAndFloat32Iterator(t *testing.T) {
+	pp := PointCloud{
+		PointCloudHeader: PointCloudHeader{
+			Fields: []string{"label", "x"},
+			Type:   []string{"U", "F"},
+			Size:   []int{4, 4},
+			Count:  []int{1, 1},
+			Width:  3,
+			Height: 1,
+		},
+		Points: 3,
+		Data:   make([]byte, 3*4*2),
+	}
+	if ok := t.Run("SeUint32SetFloat32", func(t *testing.T) {
+		lt, err := pp.Uint32Iterator("label")
+		if err != nil {
+			t.Fatal(err)
+		}
+		it, err := pp.Float32Iterator("x")
+		if err != nil {
+			t.Fatal(err)
+		}
+		lt.SetUint32(1)
+		lt.Incr()
+		lt.SetUint32(2)
+		lt.Incr()
+		lt.SetUint32(3)
+
+		it.SetFloat32(1.0)
+		it.Incr()
+		it.SetFloat32(2.0)
+		it.Incr()
+		it.SetFloat32(3.0)
+
+		bytesExpected := []byte{
+			0x01, 0x00, 0x00, 0x00, // 1
+			0x00, 0x00, 0x80, 0x3F, // 1.0
+			0x02, 0x00, 0x00, 0x00, // 2
+			0x00, 0x00, 0x00, 0x40, // 2.0
+			0x03, 0x00, 0x00, 0x00, // 3
+			0x00, 0x00, 0x40, 0x40, // 3.0
+		}
+		if !bytes.Equal(bytesExpected, pp.Data) {
+			t.Errorf("Expected data: %v, got: %v", bytesExpected, pp.Data)
+		}
+	}); !ok {
+		t.FailNow()
+	}
+
+	t.Run("Uint32Float32", func(t *testing.T) {
+		it, err := pp.Float32Iterator("x")
+		if err != nil {
+			t.Fatal(err)
+		}
+		lt, err := pp.Uint32Iterator("label")
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectedLabels := []uint32{1, 2, 3}
+		for i, expectedLabel := range expectedLabels {
+			if !lt.IsValid() {
+				t.Fatalf("Iterator is invalid at position %d", i)
+			}
+			if v := lt.Uint32(); v != expectedLabel {
+				t.Errorf("Expected: %v, got: %v", expectedLabel, v)
+			}
+			lt.Incr()
+		}
+		expectedXs := []float32{1.0, 2.0, 3.0}
+		for i, expectedX := range expectedXs {
+			if !it.IsValid() {
+				t.Fatalf("Iterator is invalid at position %d", i)
+			}
+			if v := it.Float32(); v != expectedX {
+				t.Errorf("Expected: %v, got: %v", expectedX, v)
+			}
+			it.Incr()
+		}
+	})
+
+	t.Run("Uint32Float32At", func(t *testing.T) {
+		lt, err := pp.Uint32Iterator("label")
+		if err != nil {
+			t.Fatal(err)
+		}
+		it, err := pp.Float32Iterator("x")
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectedLabels := []uint32{1, 2, 3}
+		for i, expectedLabel := range expectedLabels {
+			if !lt.IsValid() {
+				t.Fatalf("Iterator is invalid at position %d", i)
+			}
+			if v := lt.Uint32At(i); v != expectedLabel {
+				t.Errorf("Expected: %v, got: %v", expectedLabel, v)
+			}
+		}
+		expectedXs := []float32{1.0, 2.0, 3.0}
+		for i, expectedX := range expectedXs {
+			if !it.IsValid() {
+				t.Fatalf("Iterator is invalid at position %d", i)
+			}
+			if v := it.Float32At(i); v != expectedX {
+				t.Errorf("Expected: %v, got: %v", expectedX, v)
 			}
 		}
 	})

--- a/pc/iterator_test.go
+++ b/pc/iterator_test.go
@@ -132,7 +132,7 @@ func TestUint32Iterator(t *testing.T) {
 		Points: 3,
 		Data:   make([]byte, 3*4),
 	}
-	if ok := t.Run("SeUint32", func(t *testing.T) {
+	if ok := t.Run("SetUint32", func(t *testing.T) {
 		it, err := pp.Uint32Iterator("label")
 		if err != nil {
 			t.Fatal(err)
@@ -202,7 +202,7 @@ func TestFloat32IteratorAndUint32Iterator(t *testing.T) {
 		Points: 3,
 		Data:   make([]byte, 3*4*2),
 	}
-	if ok := t.Run("SetFloat32SeUint32", func(t *testing.T) {
+	if ok := t.Run("SetFloat32SetUint32", func(t *testing.T) {
 		it, err := pp.Float32Iterator("x")
 		if err != nil {
 			t.Fatal(err)

--- a/pc/iterator_test.go
+++ b/pc/iterator_test.go
@@ -411,6 +411,75 @@ func TestUint32IteratorAndFloat32Iterator(t *testing.T) {
 	})
 }
 
+func TestBinaryFloat32Iterator(t *testing.T) {
+
+	data := make([]byte, 3*4)
+
+	if ok := t.Run("SetFloat32", func(t *testing.T) {
+		it := binaryFloat32Iterator{
+			binaryIterator{
+				data:   data,
+				pos:    0,
+				stride: 4,
+			},
+		}
+		it.SetFloat32(1.0)
+		it.Incr()
+		it.SetFloat32(2.0)
+		it.Incr()
+		it.SetFloat32(3.0)
+		bytesExpected := []byte{
+			0x00, 0x00, 0x80, 0x3F, // 1.0
+			0x00, 0x00, 0x00, 0x40, // 2.0
+			0x00, 0x00, 0x40, 0x40, // 3.0
+		}
+		if !bytes.Equal(bytesExpected, data) {
+			t.Errorf("Expected data: %v, got: %v", bytesExpected, data)
+		}
+	}); !ok {
+		t.FailNow()
+	}
+
+	t.Run("Float32", func(t *testing.T) {
+		it := binaryFloat32Iterator{
+			binaryIterator{
+				data:   data,
+				pos:    0,
+				stride: 4,
+			},
+		}
+		expectedXs := []float32{1.0, 2.0, 3.0}
+		for i, expectedX := range expectedXs {
+			if !it.IsValid() {
+				t.Fatalf("Iterator is invalid at position %d", i)
+			}
+			if v := it.Float32(); v != expectedX {
+				t.Errorf("Expected: %v, got: %v", expectedX, v)
+			}
+			it.Incr()
+		}
+	})
+
+	t.Run("Float32At", func(t *testing.T) {
+		it := binaryFloat32Iterator{
+			binaryIterator{
+				data:   data,
+				pos:    0,
+				stride: 4,
+			},
+		}
+		expectedXs := []float32{1.0, 2.0, 3.0}
+		for i, expectedX := range expectedXs {
+			if !it.IsValid() {
+				t.Fatalf("Iterator is invalid at position %d", i)
+			}
+			if v := it.Float32At(i); v != expectedX {
+				t.Errorf("Expected: %v, got: %v", expectedX, v)
+			}
+		}
+	})
+}
+
 func BenchmarkFloat32Iterator(b *testing.B) {
 	const num = 1024
 	testCases := map[string]struct {

--- a/pc/iterator_test.go
+++ b/pc/iterator_test.go
@@ -314,7 +314,7 @@ func TestUint32IteratorAndFloat32Iterator(t *testing.T) {
 		Points: 3,
 		Data:   make([]byte, 3*4*2),
 	}
-	if ok := t.Run("SeUint32SetFloat32", func(t *testing.T) {
+	if ok := t.Run("SetUint32SetFloat32", func(t *testing.T) {
 		lt, err := pp.Uint32Iterator("label")
 		if err != nil {
 			t.Fatal(err)

--- a/pc/iterator_test.go
+++ b/pc/iterator_test.go
@@ -155,6 +155,22 @@ func TestUint32Iterator(t *testing.T) {
 		t.FailNow()
 	}
 
+	t.Run("Uint32At", func(t *testing.T) {
+		it, err := pp.Uint32Iterator("label")
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectedLabels := []uint32{1, 2, 3}
+		for i, expectedLabel := range expectedLabels {
+			if !it.IsValid() {
+				t.Fatalf("Iterator is invalid at position %d", i)
+			}
+			if v := it.Uint32At(i); v != expectedLabel {
+				t.Errorf("Expected: %v, got: %v", expectedLabel, v)
+			}
+		}
+	})
+
 	t.Run("Uint32", func(t *testing.T) {
 		it, err := pp.Uint32Iterator("label")
 		if err != nil {
@@ -166,7 +182,7 @@ func TestUint32Iterator(t *testing.T) {
 				t.Fatalf("Iterator is invalid at position %d", i)
 			}
 			if v := it.Uint32(); v != expectedLabel {
-				t.Errorf("Expected Vec3: %v, got: %v", expectedLabel, v)
+				t.Errorf("Expected: %v, got: %v", expectedLabel, v)
 			}
 			it.Incr()
 		}
@@ -237,7 +253,7 @@ func TestFloat32IteratorAndUint32Iterator(t *testing.T) {
 				t.Fatalf("Iterator is invalid at position %d", i)
 			}
 			if v := it.Float32(); v != expectedX {
-				t.Errorf("Expected Vec3: %v, got: %v", expectedX, v)
+				t.Errorf("Expected: %v, got: %v", expectedX, v)
 			}
 			it.Incr()
 		}
@@ -248,9 +264,39 @@ func TestFloat32IteratorAndUint32Iterator(t *testing.T) {
 				t.Fatalf("Iterator is invalid at position %d", i)
 			}
 			if v := lt.Uint32(); v != expectedLabel {
-				t.Errorf("Expected Vec3: %v, got: %v", expectedLabel, v)
+				t.Errorf("Expected: %v, got: %v", expectedLabel, v)
 			}
 			lt.Incr()
+		}
+	})
+
+	t.Run("Float32Uint32At", func(t *testing.T) {
+		it, err := pp.Float32Iterator("x")
+		if err != nil {
+			t.Fatal(err)
+		}
+		lt, err := pp.Uint32Iterator("label")
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectedXs := []float32{1.0, 2.0, 3.0}
+		for i, expectedX := range expectedXs {
+			if !it.IsValid() {
+				t.Fatalf("Iterator is invalid at position %d", i)
+			}
+			if v := it.Float32At(i); v != expectedX {
+				t.Errorf("Expected Vec3: %v, got: %v", expectedX, v)
+			}
+		}
+
+		expectedLabels := []uint32{1, 2, 3}
+		for i, expectedLabel := range expectedLabels {
+			if !lt.IsValid() {
+				t.Fatalf("Iterator is invalid at position %d", i)
+			}
+			if v := lt.Uint32At(i); v != expectedLabel {
+				t.Errorf("Expected: %v, got: %v", expectedLabel, v)
+			}
 		}
 	})
 }


### PR DESCRIPTION
I noticed the last element of the last field was not read when using an iterator in a pointcloud with mixed field type (e.g. `F` and `U`). Basically the `IsValid` method is returning false. I added some tests before introducing a fix in 2febd109892bea41612e6761cf86ffbc5e873471. Without 2febd109892bea41612e6761cf86ffbc5e873471 they should fail.

This is a minimal example to reproduce the issue:
```
package main

import (
	"fmt"

	"github.com/seqsense/pcgol/pc"
)

func main() {
	pp := &pc.PointCloud{
		PointCloudHeader: pc.PointCloudHeader{
			Fields: []string{"x", "label"},
			Size:   []int{4, 4},
			Type:   []string{"F", "U"},
			Count:  []int{1, 1},
			Width:  3,
			Height: 1,
		},
		Points: 3,
		Data: []byte{
			0x00, 0x00, 0x80, 0x3F, // 1.0
			0x01, 0x00, 0x00, 0x00, // 1
			0x00, 0x00, 0x00, 0x40, // 2.0
			0x02, 0x00, 0x00, 0x00, // 2
			0x00, 0x00, 0x40, 0x40, // 3.0
			0x03, 0x00, 0x00, 0x00, // 3
		},
	}

	iit, _ := pp.Float32Iterator("x")
	llt, _ := pp.Uint32Iterator("label")
	count1 := 0
	count2 := 0
	for ; iit.IsValid(); iit.Incr() {
		v := iit.Float32()
		fmt.Println(v)
		count2++
	}
	for ; llt.IsValid(); llt.Incr() {
		l := llt.Uint32()
		fmt.Println(l)
		count1++
	}
	fmt.Println("count2: ", count2)
	fmt.Println("count1: ", count1)
}
```
Using `master`, it should output the following where the last label is missing:
```
1
2
3
1
2
count2:  3
count1:  2
```