### PR TITLE
pc/io: add default viewpoint if missing

### DIFF
--- a/pc/io.go
+++ b/pc/io.go
@@ -221,6 +221,15 @@ func Marshal(pp *PointCloud, w io.Writer) error {
 		}
 		return ret
 	}
+
+	// Set a default value to Viewpoint if it was not provided.
+	// Viewpoint is optional for all computation so it might not be always filled in
+	// when manually creating PointCloud object but it is required by pcl_viewer and
+	// pcdeditor to successfully load a pcd file.
+	if len(pp.Viewpoint) == 0 {
+		pp.Viewpoint = []float32{0, 0, 0, 1, 0, 0, 0}
+	}
+
 	header := fmt.Sprintf(
 		`VERSION %0.1f
 FIELDS %s

--- a/pc/io_test.go
+++ b/pc/io_test.go
@@ -133,7 +133,7 @@ func TestMarshal(t *testing.T) {
 		for name, tt := range testCases {
 			tt := tt
 			t.Run(name, func(t *testing.T) {
-				obuf := bytes.NewBufferString("")
+				obuf := &bytes.Buffer{}
 				err := Marshal(tt.pp, obuf)
 				if err != nil {
 					t.Fatal(err)

--- a/pc/io_test.go
+++ b/pc/io_test.go
@@ -1,9 +1,11 @@
 package pc
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -71,4 +73,79 @@ func TestUnmarshalAscii(t *testing.T) {
 		vt.Incr()
 		lt.Incr()
 	}
+}
+
+func TestMarshal(t *testing.T) {
+	t.Run("CheckViewPoint", func(t *testing.T) {
+		testCases := map[string]struct {
+			pp             *PointCloud
+			expectedHeader PointCloudHeader
+		}{
+			"NoViewpointProvided": {
+				pp: &PointCloud{
+					PointCloudHeader: PointCloudHeader{
+						Fields: []string{"x", "y", "z"},
+						Size:   []int{4, 4, 4},
+						Count:  []int{1, 1, 1},
+						Type:   []string{"F", "F", "F"},
+						Width:  3,
+						Height: 1,
+					},
+					Points: 3,
+					Data:   make([]byte, 3*4*3),
+				},
+				expectedHeader: PointCloudHeader{
+					Fields:    []string{"x", "y", "z"},
+					Size:      []int{4, 4, 4},
+					Count:     []int{1, 1, 1},
+					Type:      []string{"F", "F", "F"},
+					Width:     3,
+					Height:    1,
+					Viewpoint: []float32{0, 0, 0, 1, 0, 0, 0},
+				},
+			},
+			"ViewpointProvided": {
+				pp: &PointCloud{
+					PointCloudHeader: PointCloudHeader{
+						Fields:    []string{"x", "y", "z"},
+						Size:      []int{4, 4, 4},
+						Count:     []int{1, 1, 1},
+						Type:      []string{"F", "F", "F"},
+						Width:     3,
+						Height:    1,
+						Viewpoint: []float32{1, 2, 3, -0.333, 0.003, 0.895, -0.298},
+					},
+					Points: 3,
+					Data:   make([]byte, 3*4*3),
+				},
+				expectedHeader: PointCloudHeader{
+					Fields:    []string{"x", "y", "z"},
+					Size:      []int{4, 4, 4},
+					Count:     []int{1, 1, 1},
+					Type:      []string{"F", "F", "F"},
+					Width:     3,
+					Height:    1,
+					Viewpoint: []float32{1, 2, 3, -0.333, 0.003, 0.895, -0.298},
+				},
+			},
+		}
+
+		for name, tt := range testCases {
+			tt := tt
+			t.Run(name, func(t *testing.T) {
+				obuf := bytes.NewBufferString("")
+				err := Marshal(tt.pp, obuf)
+				if err != nil {
+					t.Fatal(err)
+				}
+				pp2, err := Unmarshal(obuf)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(tt.expectedHeader, pp2.PointCloudHeader) {
+					t.Errorf("Expected %v, got %v", tt.expectedHeader, pp2.PointCloudHeader)
+				}
+			})
+		}
+	})
 }


### PR DESCRIPTION
This PR simply adds a value to the viewpoint field in the pointcloud object header to prevent the following error:

Using `pcl_viewer`: 
```
> Loading xxxxxxx.pcd [pcl::PCDReader::readHeader] Not enough number of elements in <VIEWPOINT>! Need 7 values (tx ty tz qw qx qy qz).
```

Using `pcdeditor`:
```
Uncaught (in promise) Error: header field must have value
    valueNew http://localhost:8080/wasm_exec.js:433
    _resume http://localhost:8080/wasm_exec.js:581
    _makeFuncWrapper http://localhost:8080/wasm_exec.js:592
    valueCall http://localhost:8080/wasm_exec.js:399
    _resume http://localhost:8080/wasm_exec.js:581
    _makeFuncWrapper http://localhost:8080/wasm_exec.js:592
    valueNew http://localhost:8080/wasm_exec.js:433
    _resume http://localhost:8080/wasm_exec.js:581
    _makeFuncWrapper http://localhost:8080/wasm_exec.js:592
    loadSubPCD http://localhost:8080/pcdeditor.esm.js:365
    promise callback*loadSubPCD/< http://localhost:8080/pcdeditor.esm.js:364
    loadSubPCD http://localhost:8080/pcdeditor.esm.js:355
    onchange http://localhost:8080/pcdeditor.esm.js:227
wasm_exec.js:433:31
```