### PR TITLE
pc/storage/kdtree: fix tree maxDepth

### DIFF
--- a/pc/storage/kdtree/kdtree.go
+++ b/pc/storage/kdtree/kdtree.go
@@ -340,9 +340,9 @@ func (n *node) maxDepth(depth int) int {
 	d0 := n.children[0].maxDepth(depth + 1)
 	d1 := n.children[1].maxDepth(depth + 1)
 	if d0 > d1 {
-		return d1
+		return d0
 	}
-	return d0
+	return d1
 }
 
 type indiceSorter struct {

--- a/pc/storage/kdtree/kdtree_test.go
+++ b/pc/storage/kdtree/kdtree_test.go
@@ -59,6 +59,63 @@ func createTestPointCloud(t *testing.T) pc.Vec3Iterator {
 	return it
 }
 
+func TestNode_maxDepth(t *testing.T) {
+	testCases := map[string]struct {
+		ra       pc.Vec3RandomAccessor
+		expected int
+	}{
+		"Depth=2": {
+			ra: pc.Vec3Slice{
+				{4, 1, 0}, {2, 2, 1},
+			},
+			//  n
+			//  |
+			//  n  maxDepth=2
+			expected: 2,
+		},
+		"Depth=2,Balanced": {
+			ra: pc.Vec3Slice{
+				{4, 1, 0}, {2, 2, 1}, {5, 0, 0},
+			},
+			//     n
+			//    / \
+			//   n   n  maxDepth=2
+			expected: 2,
+		},
+		"Depth=3": {
+			ra: pc.Vec3Slice{
+				{4, 1, 0}, {2, 2, 1}, {5, 0, 0}, {3, 0, 0}, {0, 1, 0}, {1, 0, 0},
+			},
+			//     n
+			//    / \
+			//   n   n
+			//  / \  |
+			// n   n n  maxDepth=3
+			expected: 3,
+		},
+		"Depth=3,Balanced": {
+			ra: pc.Vec3Slice{
+				{4, 1, 0}, {2, 2, 1}, {5, 0, 0}, {3, 0, 0}, {0, 1, 0}, {1, 0, 0}, {6, 2, 1},
+			},
+			//      n
+			//    /   \
+			//   n     n
+			//  / \   / \
+			// n   n n   n maxDepth=3
+			expected: 3,
+		},
+	}
+	for name, tt := range testCases {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			kdt := New(tt.ra)
+			if d := kdt.root.maxDepth(0); d != tt.expected {
+				t.Errorf("Expected max depth: %d, got: %d\n%s", tt.expected, d, kdt)
+			}
+		})
+	}
+}
+
 func kdtreeDeepExpectEqual(t *testing.T, a, b *KDTree) bool {
 	t.Helper()
 	return reflect.DeepEqual(a.root, b.root) && reflect.DeepEqual(a.Vec3RandomAccessor, b.Vec3RandomAccessor)


### PR DESCRIPTION
Memory reallocation is reduced.

### master branch:
```
BenchmarkKDTree_Nearest/100points/KDTree     7587950     788 ns/op  209 B/op  5 allocs/op
BenchmarkKDTree_Nearest/100points/Naive      5848702    1018 ns/op    0 B/op  0 allocs/op
BenchmarkKDTree_Nearest/1000points/KDTree    4872494    1232 ns/op  323 B/op  8 allocs/op
BenchmarkKDTree_Nearest/1000points/Naive      623833    9476 ns/op    0 B/op  0 allocs/op
BenchmarkKDTree_Nearest/10000points/KDTree   4327732    1377 ns/op  294 B/op  7 allocs/op
BenchmarkKDTree_Nearest/10000points/Naive      63553   93568 ns/op    0 B/op  0 allocs/op
BenchmarkKDTree_Nearest/100000points/KDTree  3774097    1589 ns/op  395 B/op  6 allocs/op
BenchmarkKDTree_Nearest/100000points/Naive      6298  942415 ns/op    0 B/op  0 allocs/op
```

### fixed:
```
BenchmarkKDTree_Nearest/100points/KDTree     8880758     674 ns/op  113 B/op  4 allocs/op
BenchmarkKDTree_Nearest/100points/Naive      5890285    1021 ns/op    0 B/op  0 allocs/op
BenchmarkKDTree_Nearest/1000points/KDTree    5423318    1106 ns/op  179 B/op  7 allocs/op
BenchmarkKDTree_Nearest/1000points/Naive      626694    9456 ns/op    0 B/op  0 allocs/op
BenchmarkKDTree_Nearest/10000points/KDTree   4723938    1268 ns/op  169 B/op  7 allocs/op
BenchmarkKDTree_Nearest/10000points/Naive      63748   93588 ns/op    0 B/op  0 allocs/op
BenchmarkKDTree_Nearest/100000points/KDTree  4364542    1378 ns/op  139 B/op  5 allocs/op
BenchmarkKDTree_Nearest/100000points/Naive      6310  944485 ns/op    0 B/op  0 allocs/op
```