### PR TITLE
pc/storage/kdtree: fix delete point

### DIFF
--- a/pc/storage/kdtree/kdtree.go
+++ b/pc/storage/kdtree/kdtree.go
@@ -254,13 +254,16 @@ func (k *KDTree) deleteNodeImpl(n *node, pID int, depth int) (*node, error) {
 
 	pointAtNode := k.Vec3At(n.id)
 	p := k.Vec3At(pID)
-	if p[n.dim] < pointAtNode[n.dim] {
+
+	if p[n.dim] <= pointAtNode[n.dim] {
 		child, err := k.deleteNodeImpl(n.children[0], pID, depth+1)
 		if err != nil {
 			return nil, err
 		}
 		n.children[0] = child
-	} else {
+	}
+
+	if p[n.dim] >= pointAtNode[n.dim] {
 		child, err := k.deleteNodeImpl(n.children[1], pID, depth+1)
 		if err != nil {
 			return nil, err

--- a/pc/storage/kdtree/kdtree_test.go
+++ b/pc/storage/kdtree/kdtree_test.go
@@ -717,6 +717,28 @@ func TestKDtree(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("DeletePointTreeWithAllPointsOnALine", func(t *testing.T) {
+		var it pc.Vec3RandomAccessor = pc.Vec3Slice{
+			mat.Vec3{4, 0, 0},
+			mat.Vec3{1, 0, 0},
+			mat.Vec3{2, 0, 0},
+			mat.Vec3{3, 0, 0},
+		}
+
+		kdt := New(it)
+		for i := 0; i < it.Len(); i++ {
+			p := it.Vec3At(i)
+			err := kdt.DeletePoint(i)
+			if err != nil {
+				t.Fatal(err)
+			}
+			n := kdt.Nearest(p, 0.001)
+			if n.ID >= 0 {
+				t.Fatalf("%d, %v was not deleted\n", i, p)
+			}
+		}
+	})
 }
 
 func ExampleKDTree_String() {


### PR DESCRIPTION
While working with [this pcd file](https://github.com/seqsense/pcdeditor/blob/master/fixture/map.pcd), I ran into a situation where some point were not correctly deleted (e.g. index `32085`). This PR adds a minimal test case reproducing the issue and a fix is proposed.