### PR TITLE
pc/uint32 random accessor

### DIFF
--- a/pc/indice.go
+++ b/pc/indice.go
@@ -23,3 +23,23 @@ func NewIndiceVec3RandomAccessor(ra Vec3RandomAccessor, indice []int) Vec3Random
 		indice: indice,
 	}
 }
+
+type indiceUint32RandomAccessor struct {
+	indice []int
+	ra     Uint32RandomAccessor
+}
+
+func (i *indiceUint32RandomAccessor) Len() int {
+	return len(i.indice)
+}
+
+func (i *indiceUint32RandomAccessor) Uint32At(j int) uint32 {
+	return i.ra.Uint32At(i.indice[j])
+}
+
+func NewIndiceUint32RandomAccessor(ra Uint32RandomAccessor, indice []int) Uint32RandomAccessor {
+	return &indiceUint32RandomAccessor{
+		ra:     ra,
+		indice: indice,
+	}
+}

--- a/pc/indice_test.go
+++ b/pc/indice_test.go
@@ -1,0 +1,128 @@
+package pc
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/seqsense/pcgol/mat"
+)
+
+func TestIndiceVec3RandomAccessor(t *testing.T) {
+	var ra Vec3RandomAccessor = Vec3Slice{
+		mat.Vec3{1, 0, 0},
+		mat.Vec3{2, 0, 0},
+		mat.Vec3{3, 0, 0},
+		mat.Vec3{4, 0, 0},
+	}
+
+	testCases := []struct {
+		indices       []int
+		expectedLen   int
+		expectedVec3s Vec3Slice
+	}{
+		{
+			indices:       []int{},
+			expectedLen:   0,
+			expectedVec3s: Vec3Slice{},
+		},
+		{
+			indices:     []int{0, 1, 2, 3},
+			expectedLen: 4,
+			expectedVec3s: Vec3Slice{
+				mat.Vec3{1, 0, 0},
+				mat.Vec3{2, 0, 0},
+				mat.Vec3{3, 0, 0},
+				mat.Vec3{4, 0, 0},
+			},
+		},
+		{
+			indices:     []int{0, 2},
+			expectedLen: 2,
+			expectedVec3s: Vec3Slice{
+				mat.Vec3{1, 0, 0},
+				mat.Vec3{3, 0, 0},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(fmt.Sprintf("%v", tt.indices),
+			func(t *testing.T) {
+				iRa := NewIndiceVec3RandomAccessor(ra, tt.indices)
+				if iRa.Len() != tt.expectedLen {
+					t.Fatalf("Expected: %d, got %d", tt.expectedLen, iRa.Len())
+				}
+
+				vec3s := Vec3Slice{}
+				for i := 0; i < iRa.Len(); i++ {
+					vec3s = append(vec3s, iRa.Vec3At(i))
+				}
+				if !reflect.DeepEqual(tt.expectedVec3s, vec3s) {
+					t.Fatalf("Expected: %v, got %v", tt.expectedVec3s, vec3s)
+				}
+			},
+		)
+	}
+}
+
+type dummyUint32RandomAccessor struct {
+	values []uint32
+}
+
+func (ra *dummyUint32RandomAccessor) Len() int {
+	return len(ra.values)
+}
+
+func (ra *dummyUint32RandomAccessor) Uint32At(i int) uint32 {
+	return ra.values[i]
+}
+
+func TestIndiceUint32RandomAccessor(t *testing.T) {
+	ra := &dummyUint32RandomAccessor{
+		values: []uint32{1, 2, 3, 4},
+	}
+
+	testCases := []struct {
+		indices         []int
+		expectedLen     int
+		expectedUint32s []uint32
+	}{
+		{
+			indices:         []int{},
+			expectedLen:     0,
+			expectedUint32s: []uint32{},
+		},
+		{
+			indices:         []int{0, 1, 2, 3},
+			expectedLen:     4,
+			expectedUint32s: []uint32{1, 2, 3, 4},
+		},
+		{
+			indices:         []int{0, 2},
+			expectedLen:     2,
+			expectedUint32s: []uint32{1, 3},
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(fmt.Sprintf("%v", tt.indices),
+			func(t *testing.T) {
+				iRa := NewIndiceUint32RandomAccessor(ra, tt.indices)
+				if iRa.Len() != tt.expectedLen {
+					t.Fatalf("Expected: %d, got %d", tt.expectedLen, iRa.Len())
+				}
+
+				uint32s := []uint32{}
+				for i := 0; i < iRa.Len(); i++ {
+					uint32s = append(uint32s, iRa.Uint32At(i))
+				}
+				if !reflect.DeepEqual(tt.expectedUint32s, uint32s) {
+					t.Fatalf("Expected: %v, got %v", tt.expectedUint32s, uint32s)
+				}
+			},
+		)
+	}
+}

--- a/pc/iterator.go
+++ b/pc/iterator.go
@@ -152,12 +152,11 @@ func (i naiveVec3Iterator) SetVec3(v mat.Vec3) {
 }
 
 type Uint32Iterator interface {
+	Uint32RandomAccessor
 	Incr()
 	IsValid() bool
 	Uint32() uint32
 	SetUint32(uint32)
-	Uint32At(int) uint32
-	Len() int
 }
 
 type binaryUint32Iterator struct {

--- a/pc/randomaccess.go
+++ b/pc/randomaccess.go
@@ -8,3 +8,8 @@ type Vec3RandomAccessor interface {
 	Vec3At(int) mat.Vec3
 	Len() int
 }
+
+type Uint32RandomAccessor interface {
+	Uint32At(int) uint32
+	Len() int
+}

--- a/pc/segmentation/regiongrowing/regiongrowing.go
+++ b/pc/segmentation/regiongrowing/regiongrowing.go
@@ -10,10 +10,10 @@ const initialSliceCap = 8192
 
 type RegionGrowing struct {
 	search       storage.Search
-	propertyIter pc.Uint32Iterator
+	propertyIter pc.Uint32RandomAccessor
 }
 
-func New(search storage.Search, propertyIter pc.Uint32Iterator) *RegionGrowing {
+func New(search storage.Search, propertyIter pc.Uint32RandomAccessor) *RegionGrowing {
 	return &RegionGrowing{
 		search:       search,
 		propertyIter: propertyIter,


### PR DESCRIPTION
This PR adds `Uint32RandomAccessor` and `indiceUint32RandomAccessor`. These interface/struct are the equivalent of`Vec3RandomAccessor` and `indiceVec3RandomAccessor` but to access `uint32` field.