### PR TITLE
pc: add RawIndex getter to iterator and accessor interfaces

### DIFF
--- a/pc/indice.go
+++ b/pc/indice.go
@@ -17,6 +17,10 @@ func (i *indiceVec3RandomAccessor) Vec3At(j int) mat.Vec3 {
 	return i.ra.Vec3At(i.indice[j])
 }
 
+func (i *indiceVec3RandomAccessor) RawIndexAt(j int) int {
+	return i.indice[j]
+}
+
 func NewIndiceVec3RandomAccessor(ra Vec3RandomAccessor, indice []int) Vec3RandomAccessor {
 	return &indiceVec3RandomAccessor{
 		ra:     ra,
@@ -35,6 +39,10 @@ func (i *indiceUint32RandomAccessor) Len() int {
 
 func (i *indiceUint32RandomAccessor) Uint32At(j int) uint32 {
 	return i.ra.Uint32At(i.indice[j])
+}
+
+func (i *indiceUint32RandomAccessor) RawIndexAt(j int) int {
+	return i.indice[j]
 }
 
 func NewIndiceUint32RandomAccessor(ra Uint32RandomAccessor, indice []int) Uint32RandomAccessor {

--- a/pc/indice_test.go
+++ b/pc/indice_test.go
@@ -56,11 +56,16 @@ func TestIndiceVec3RandomAccessor(t *testing.T) {
 				}
 
 				vec3s := Vec3Slice{}
+				indexes := []int{}
 				for i := 0; i < iRa.Len(); i++ {
 					vec3s = append(vec3s, iRa.Vec3At(i))
+					indexes = append(indexes, iRa.RawIndexAt(i))
 				}
 				if !reflect.DeepEqual(tt.expectedVec3s, vec3s) {
 					t.Fatalf("Expected: %v, got %v", tt.expectedVec3s, vec3s)
+				}
+				if !reflect.DeepEqual(tt.indices, indexes) {
+					t.Fatalf("Expected indexes: %v, got %v", tt.indices, indexes)
 				}
 			},
 		)
@@ -77,6 +82,10 @@ func (ra *dummyUint32RandomAccessor) Len() int {
 
 func (ra *dummyUint32RandomAccessor) Uint32At(i int) uint32 {
 	return ra.values[i]
+}
+
+func (ra *dummyUint32RandomAccessor) RawIndexAt(i int) int {
+	return i
 }
 
 func TestIndiceUint32RandomAccessor(t *testing.T) {
@@ -116,11 +125,16 @@ func TestIndiceUint32RandomAccessor(t *testing.T) {
 				}
 
 				uint32s := []uint32{}
+				indexes := []int{}
 				for i := 0; i < iRa.Len(); i++ {
 					uint32s = append(uint32s, iRa.Uint32At(i))
+					indexes = append(indexes, iRa.RawIndexAt(i))
 				}
 				if !reflect.DeepEqual(tt.expectedUint32s, uint32s) {
 					t.Fatalf("Expected: %v, got %v", tt.expectedUint32s, uint32s)
+				}
+				if !reflect.DeepEqual(tt.indices, indexes) {
+					t.Fatalf("Expected indexes: %v, got %v", tt.indices, indexes)
 				}
 			},
 		)

--- a/pc/iterator.go
+++ b/pc/iterator.go
@@ -39,6 +39,7 @@ type Float32ConstForwardIterator interface {
 	Incr()
 	IsValid() bool
 	Float32() float32
+	// RawIndex returns the index of the current item on the base PointCloud storage
 	RawIndex() int
 }
 
@@ -56,6 +57,7 @@ type Vec3ConstForwardIterator interface {
 	Incr()
 	IsValid() bool
 	Vec3() mat.Vec3
+	// RawIndex returns the index of the current item on the base PointCloud storage
 	RawIndex() int
 }
 
@@ -198,6 +200,7 @@ type Uint32ConstForwardIterator interface {
 	Incr()
 	IsValid() bool
 	Uint32() uint32
+	// RawIndex returns the index of the current item on the base PointCloud storage
 	RawIndex() int
 }
 

--- a/pc/iterator.go
+++ b/pc/iterator.go
@@ -21,13 +21,25 @@ func (i *binaryIterator) Len() int {
 	return len(i.data) / i.stride
 }
 
+func (i *binaryIterator) RawIndex() int {
+	return i.pos / i.stride
+}
+
 type Float32Iterator interface {
+	Float32RandomAccessor
+	Float32ForwardIterator
+}
+
+type Float32ForwardIterator interface {
+	Float32ConstForwardIterator
+	SetFloat32(float32)
+}
+
+type Float32ConstForwardIterator interface {
 	Incr()
 	IsValid() bool
 	Float32() float32
-	SetFloat32(float32)
-	Float32At(int) float32
-	Len() int
+	RawIndex() int
 }
 
 type Vec3Iterator interface {
@@ -44,6 +56,7 @@ type Vec3ConstForwardIterator interface {
 	Incr()
 	IsValid() bool
 	Vec3() mat.Vec3
+	RawIndex() int
 }
 
 type binaryFloat32Iterator struct {
@@ -72,6 +85,10 @@ func (i *binaryFloat32Iterator) SetFloat32(v float32) {
 
 func (i *binaryFloat32Iterator) IsValid() bool {
 	return i.pos+4 <= len(i.data)
+}
+
+func (i *binaryFloat32Iterator) RawIndexAt(j int) int {
+	return i.RawIndex() + j
 }
 
 type float32Iterator struct {
@@ -121,6 +138,14 @@ func (i *float32Iterator) SetVec3(v mat.Vec3) {
 	copy(i.data[i.pos:i.pos+3], v[:])
 }
 
+func (i *float32Iterator) RawIndex() int {
+	return i.pos / i.stride
+}
+
+func (i *float32Iterator) RawIndexAt(j int) int {
+	return i.pos/i.stride + j
+}
+
 type naiveVec3Iterator [3]Float32Iterator
 
 func (i naiveVec3Iterator) IsValid() bool {
@@ -151,12 +176,29 @@ func (i naiveVec3Iterator) SetVec3(v mat.Vec3) {
 	i[2].SetFloat32(v[2])
 }
 
+func (i naiveVec3Iterator) RawIndex() int {
+	return i[0].RawIndex()
+}
+
+func (i naiveVec3Iterator) RawIndexAt(j int) int {
+	return i[0].RawIndexAt(j)
+}
+
 type Uint32Iterator interface {
 	Uint32RandomAccessor
+	Uint32ForwardIterator
+}
+
+type Uint32ForwardIterator interface {
+	Uint32ConstForwardIterator
+	SetUint32(uint32)
+}
+
+type Uint32ConstForwardIterator interface {
 	Incr()
 	IsValid() bool
 	Uint32() uint32
-	SetUint32(uint32)
+	RawIndex() int
 }
 
 type binaryUint32Iterator struct {
@@ -180,4 +222,8 @@ func (i *binaryUint32Iterator) SetUint32(v uint32) {
 
 func (i *binaryUint32Iterator) IsValid() bool {
 	return i.pos+4 <= len(i.data)
+}
+
+func (i *binaryUint32Iterator) RawIndexAt(j int) int {
+	return i.RawIndex() + j
 }

--- a/pc/iterator_test.go
+++ b/pc/iterator_test.go
@@ -8,96 +8,171 @@ import (
 )
 
 func TestVec3Iterator(t *testing.T) {
-	pp := PointCloud{
-		PointCloudHeader: PointCloudHeader{
-			Fields: []string{"x", "y", "z"},
-			Size:   []int{4, 4, 4},
-			Count:  []int{1, 1, 1},
-			Width:  3,
-			Height: 1,
+	testCases := map[string]struct {
+		in            *PointCloud
+		expectedBytes []byte
+	}{
+		"BinaryIterator": {
+			in: &PointCloud{
+				PointCloudHeader: PointCloudHeader{
+					Fields: []string{"x", "y", "z"},
+					Size:   []int{4, 4, 4},
+					Count:  []int{1, 1, 1},
+					Width:  3,
+					Height: 1,
+				},
+				Points: 3,
+				Data:   make([]byte, 3*4*3),
+			},
+			expectedBytes: []byte{
+				0x00, 0x00, 0x80, 0x3F, // 1.0
+				0x00, 0x00, 0x00, 0x40, // 2.0
+				0x00, 0x00, 0x40, 0x40, // 3.0
+				0x00, 0x00, 0x80, 0x40, // 4.0
+				0x00, 0x00, 0xA0, 0x40, // 5.0
+				0x00, 0x00, 0xC0, 0x40, // 6.0
+				0x00, 0x00, 0xE0, 0x40, // 7.0
+				0x00, 0x00, 0x00, 0x41, // 8.0
+				0x00, 0x00, 0x10, 0x41, // 9.0
+			},
 		},
-		Points: 3,
-		Data:   make([]byte, 3*4*3),
+		"NaiveIterator": {
+			in: &PointCloud{
+				PointCloudHeader: PointCloudHeader{
+					Fields: []string{"y", "z", "x"},
+					Size:   []int{4, 4, 4},
+					Count:  []int{1, 1, 1},
+					Width:  3,
+					Height: 1,
+				},
+				Points: 3,
+				Data:   make([]byte, 3*4*3),
+			},
+			expectedBytes: []byte{
+				0x00, 0x00, 0x00, 0x40, // 2.0
+				0x00, 0x00, 0x40, 0x40, // 3.0
+				0x00, 0x00, 0x80, 0x3F, // 1.0
+				0x00, 0x00, 0xA0, 0x40, // 5.0
+				0x00, 0x00, 0xC0, 0x40, // 6.0
+				0x00, 0x00, 0x80, 0x40, // 4.0
+				0x00, 0x00, 0x00, 0x41, // 8.0
+				0x00, 0x00, 0x10, 0x41, // 9.0
+				0x00, 0x00, 0xE0, 0x40, // 7.0
+			},
+		},
 	}
+	for name, tt := range testCases {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			pp := tt.in
 
-	if ok := t.Run("SetVec3", func(t *testing.T) {
-		it, err := pp.Vec3Iterator()
-		if err != nil {
-			t.Fatal(err)
-		}
-		it.SetVec3(mat.Vec3{1, 2, 3})
-		it.Incr()
-		it.SetVec3(mat.Vec3{4, 5, 6})
-		it.Incr()
-		it.SetVec3(mat.Vec3{7, 8, 9})
+			if ok := t.Run("SetVec3", func(t *testing.T) {
+				it, err := pp.Vec3Iterator()
+				if err != nil {
+					t.Fatal(err)
+				}
+				it.SetVec3(mat.Vec3{1, 2, 3})
+				it.Incr()
+				it.SetVec3(mat.Vec3{4, 5, 6})
+				it.Incr()
+				it.SetVec3(mat.Vec3{7, 8, 9})
 
-		bytesExpected := []byte{
-			0x00, 0x00, 0x80, 0x3F, // 1.0
-			0x00, 0x00, 0x00, 0x40, // 2.0
-			0x00, 0x00, 0x40, 0x40, // 3.0
-			0x00, 0x00, 0x80, 0x40, // 4.0
-			0x00, 0x00, 0xA0, 0x40, // 5.0
-			0x00, 0x00, 0xC0, 0x40, // 6.0
-			0x00, 0x00, 0xE0, 0x40, // 7.0
-			0x00, 0x00, 0x00, 0x41, // 8.0
-			0x00, 0x00, 0x10, 0x41, // 9.0
-		}
-		if !bytes.Equal(bytesExpected, pp.Data) {
-			t.Errorf("Expected data: %v, got: %v", bytesExpected, pp.Data)
-		}
-	}); !ok {
-		t.FailNow()
-	}
-
-	t.Run("Vec3", func(t *testing.T) {
-		it, err := pp.Vec3Iterator()
-		if err != nil {
-			t.Fatal(err)
-		}
-		expectedVecs := []mat.Vec3{
-			{1, 2, 3},
-			{4, 5, 6},
-			{7, 8, 9},
-		}
-		for i, expectedVec := range expectedVecs {
-			if !it.IsValid() {
-				t.Fatalf("Iterator is invalid at position %d", i)
+				if !bytes.Equal(tt.expectedBytes, pp.Data) {
+					t.Errorf("Expected data: %v, got: %v", tt.expectedBytes, pp.Data)
+				}
+			}); !ok {
+				t.FailNow()
 			}
-			if v := it.Vec3(); !v.Equal(expectedVec) {
-				t.Errorf("Expected Vec3: %v, got: %v", expectedVec, v)
-			}
-			it.Incr()
-		}
-	})
 
-	t.Run("Vec3At", func(t *testing.T) {
-		it, err := pp.Vec3Iterator()
-		if err != nil {
-			t.Fatal(err)
-		}
-		expectedVecs := []mat.Vec3{
-			{1, 2, 3},
-			{4, 5, 6},
-			{7, 8, 9},
-		}
-		for i, expectedVec := range expectedVecs {
-			if !it.IsValid() {
-				t.Fatalf("Iterator is invalid at position %d", i)
-			}
-			if v := it.Vec3At(i); !v.Equal(expectedVec) {
-				t.Errorf("%d: Expected Vec3: %v, got: %v", i, expectedVec, v)
-			}
-		}
-	})
+			t.Run("Vec3", func(t *testing.T) {
+				it, err := pp.Vec3Iterator()
+				if err != nil {
+					t.Fatal(err)
+				}
+				expectedVecs := []mat.Vec3{
+					{1, 2, 3},
+					{4, 5, 6},
+					{7, 8, 9},
+				}
+				for i, expectedVec := range expectedVecs {
+					if !it.IsValid() {
+						t.Fatalf("Iterator is invalid at position %d", i)
+					}
+					if v := it.Vec3(); !v.Equal(expectedVec) {
+						t.Errorf("Expected Vec3: %v, got: %v", expectedVec, v)
+					}
+					it.Incr()
+				}
+			})
 
-	pp.PointCloudHeader = PointCloudHeader{
-		Fields: []string{"xyz"},
-		Size:   []int{4},
-		Count:  []int{3},
-		Width:  3,
-		Height: 1,
+			t.Run("Vec3At", func(t *testing.T) {
+				it, err := pp.Vec3Iterator()
+				if err != nil {
+					t.Fatal(err)
+				}
+				expectedVecs := []mat.Vec3{
+					{1, 2, 3},
+					{4, 5, 6},
+					{7, 8, 9},
+				}
+				for i, expectedVec := range expectedVecs {
+					if !it.IsValid() {
+						t.Fatalf("Iterator is invalid at position %d", i)
+					}
+					if v := it.Vec3At(i); !v.Equal(expectedVec) {
+						t.Errorf("%d: Expected Vec3: %v, got: %v", i, expectedVec, v)
+					}
+				}
+			})
+
+			t.Run("RawIndex", func(t *testing.T) {
+				it, err := pp.Vec3Iterator()
+				if err != nil {
+					t.Fatal(err)
+				}
+				for i := 0; it.IsValid(); it.Incr() {
+					if ri := it.RawIndex(); ri != i {
+						t.Errorf("%d: Expected RawIndex: %d, got: %d", i, i, ri)
+					}
+					i++
+				}
+			})
+
+			t.Run("RawIndexAt", func(t *testing.T) {
+				it, err := pp.Vec3Iterator()
+				if err != nil {
+					t.Fatal(err)
+				}
+				for i := 0; i < 3; i++ {
+					if ri := it.RawIndexAt(i); ri != i {
+						t.Errorf("%d: Expected RawIndex: %d, got: %d", i, i, ri)
+					}
+				}
+			})
+		})
 	}
 	t.Run("Vec3_XYZ", func(t *testing.T) {
+		pp := &PointCloud{
+			PointCloudHeader: PointCloudHeader{
+				Fields: []string{"xyz"},
+				Size:   []int{4},
+				Count:  []int{3},
+				Width:  3,
+				Height: 1,
+			},
+			Points: 3,
+			Data: []byte{
+				0x00, 0x00, 0x80, 0x3F, // 1.0
+				0x00, 0x00, 0x00, 0x40, // 2.0
+				0x00, 0x00, 0x40, 0x40, // 3.0
+				0x00, 0x00, 0x80, 0x40, // 4.0
+				0x00, 0x00, 0xA0, 0x40, // 5.0
+				0x00, 0x00, 0xC0, 0x40, // 6.0
+				0x00, 0x00, 0xE0, 0x40, // 7.0
+				0x00, 0x00, 0x00, 0x41, // 8.0
+				0x00, 0x00, 0x10, 0x41, // 9.0
+			},
+		}
 		it, err := pp.Vec3Iterator()
 		if err != nil {
 			t.Fatal(err)
@@ -184,6 +259,31 @@ func TestUint32Iterator(t *testing.T) {
 			}
 			if v := it.Uint32At(i); v != expectedLabel {
 				t.Errorf("Expected: %v, got: %v", expectedLabel, v)
+			}
+		}
+	})
+
+	t.Run("RawIndex", func(t *testing.T) {
+		it, err := pp.Uint32Iterator("label")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 3; i++ {
+			if ri := it.RawIndex(); ri != i {
+				t.Errorf("%d: Expected RawIndex: %d, got: %d", i, i, ri)
+			}
+			it.Incr()
+		}
+	})
+
+	t.Run("RawIndexAt", func(t *testing.T) {
+		it, err := pp.Uint32Iterator("label")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 3; i++ {
+			if ri := it.RawIndexAt(i); ri != i {
+				t.Errorf("%d: Expected RawIndex: %d, got: %d", i, i, ri)
 			}
 		}
 	})
@@ -475,6 +575,37 @@ func TestBinaryFloat32Iterator(t *testing.T) {
 			}
 			if v := it.Float32At(i); v != expectedX {
 				t.Errorf("Expected: %v, got: %v", expectedX, v)
+			}
+		}
+	})
+
+	t.Run("RawIndex", func(t *testing.T) {
+		it := binaryFloat32Iterator{
+			binaryIterator{
+				data:   data,
+				pos:    0,
+				stride: 4,
+			},
+		}
+		for i := 0; i < 3; i++ {
+			if ri := it.RawIndex(); ri != i {
+				t.Errorf("%d: Expected RawIndex: %d, got: %d", i, i, ri)
+			}
+			it.Incr()
+		}
+	})
+
+	t.Run("RawIndexAt", func(t *testing.T) {
+		it := binaryFloat32Iterator{
+			binaryIterator{
+				data:   data,
+				pos:    0,
+				stride: 4,
+			},
+		}
+		for i := 0; i < 3; i++ {
+			if ri := it.RawIndexAt(i); ri != i {
+				t.Errorf("%d: Expected RawIndex: %d, got: %d", i, i, ri)
 			}
 		}
 	})

--- a/pc/randomaccess.go
+++ b/pc/randomaccess.go
@@ -7,18 +7,21 @@ import (
 type Vec3RandomAccessor interface {
 	Vec3At(int) mat.Vec3
 	Len() int
+	// RawIndexAt returns the index of the specific item on the base PointCloud storage
 	RawIndexAt(int) int
 }
 
 type Float32RandomAccessor interface {
 	Float32At(int) float32
 	Len() int
+	// RawIndexAt returns the index of the specific item on the base PointCloud storage
 	RawIndexAt(int) int
 }
 
 type Uint32RandomAccessor interface {
 	Uint32At(int) uint32
 	Len() int
+	// RawIndexAt returns the index of the specific item on the base PointCloud storage
 	RawIndexAt(int) int
 }
 

--- a/pc/randomaccess.go
+++ b/pc/randomaccess.go
@@ -7,9 +7,44 @@ import (
 type Vec3RandomAccessor interface {
 	Vec3At(int) mat.Vec3
 	Len() int
+	RawIndexAt(int) int
+}
+
+type Float32RandomAccessor interface {
+	Float32At(int) float32
+	Len() int
+	RawIndexAt(int) int
 }
 
 type Uint32RandomAccessor interface {
 	Uint32At(int) uint32
 	Len() int
+	RawIndexAt(int) int
+}
+
+type vec3RandomAccessorIterator struct {
+	Vec3RandomAccessor
+	pos int
+}
+
+func NewVec3RandomAccessorIterator(ra Vec3RandomAccessor) Vec3ConstForwardIterator {
+	return &vec3RandomAccessorIterator{
+		Vec3RandomAccessor: ra,
+	}
+}
+
+func (i *vec3RandomAccessorIterator) Incr() {
+	i.pos++
+}
+
+func (i *vec3RandomAccessorIterator) IsValid() bool {
+	return i.pos < i.Len()
+}
+
+func (i *vec3RandomAccessorIterator) Vec3() mat.Vec3 {
+	return i.Vec3At(i.pos)
+}
+
+func (i *vec3RandomAccessorIterator) RawIndex() int {
+	return i.Vec3RandomAccessor.RawIndexAt(i.pos)
 }

--- a/pc/randomaccess_test.go
+++ b/pc/randomaccess_test.go
@@ -1,0 +1,31 @@
+package pc
+
+import (
+	"testing"
+
+	"github.com/seqsense/pcgol/mat"
+)
+
+func TestVec3RandomAccessorIterator(t *testing.T) {
+	vs := Vec3Slice([]mat.Vec3{
+		{0.0, 1.0, 0.0},
+		{0.0, 2.0, 0.0},
+		{0.0, 3.0, 0.0},
+	})
+	it := NewVec3RandomAccessorIterator(vs)
+	for i := 0; i < 3; i++ {
+		if !it.IsValid() {
+			t.Fatalf("Iterator is invalid at position %d", i)
+		}
+		if v := it.Vec3(); !v.Equal(vs.Vec3At(i)) {
+			t.Errorf("%d: Expected Vec3: %v, got: %v", i, vs.Vec3At(i), v)
+		}
+		if ri := it.RawIndex(); ri != i {
+			t.Errorf("%d: Expected RawIndex: %d, got: %d", i, i, ri)
+		}
+		it.Incr()
+	}
+	if it.IsValid() {
+		t.Fatalf("Iterator must be invalid at the end")
+	}
+}

--- a/pc/randomsample.go
+++ b/pc/randomsample.go
@@ -17,7 +17,7 @@ func NewVec3RandomSampleIterator(ra Vec3RandomAccessor, ratio float32) Vec3Const
 		if it, ok := ra.(Vec3ConstForwardIterator); ok {
 			return it
 		}
-		return &vec3RandomAccessToIterator{ra: ra}
+		return NewVec3RandomAccessorIterator(ra)
 	}
 	expectedInterval := 1 / ratio
 	return &vec3RandomSampleIterator{
@@ -47,18 +47,13 @@ func (s *vec3RandomSampleIterator) Vec3() mat.Vec3 {
 	return s.ra.Vec3At(int(s.pos))
 }
 
-type vec3RandomAccessToIterator struct {
-	ra Vec3RandomAccessor
-
-	pos float32
+func (s *vec3RandomSampleIterator) RawIndex() int {
+	return int(s.pos)
 }
-
-func (s *vec3RandomAccessToIterator) Incr()          { s.pos++ }
-func (s *vec3RandomAccessToIterator) IsValid() bool  { return int(s.pos) < s.ra.Len() }
-func (s *vec3RandomAccessToIterator) Vec3() mat.Vec3 { return s.ra.Vec3At(int(s.pos)) }
 
 type vec3EmptyIterator struct{}
 
 func (vec3EmptyIterator) Incr()          {}
 func (vec3EmptyIterator) IsValid() bool  { return false }
 func (vec3EmptyIterator) Vec3() mat.Vec3 { panic("invalid access to empty iterator") }
+func (vec3EmptyIterator) RawIndex() int  { return 0 }

--- a/pc/randomsample_test.go
+++ b/pc/randomsample_test.go
@@ -77,7 +77,12 @@ func TestVec3RandomSampleIterator(t *testing.T) {
 			var sampled Vec3Slice
 			it := NewVec3RandomSampleIterator(orig, tt.ratio)
 			for ; it.IsValid(); it.Incr() {
-				sampled = append(sampled, it.Vec3())
+				v := it.Vec3()
+				sampled = append(sampled, v)
+				i := it.RawIndex()
+				if !v.Equal(orig.Vec3At(i)) {
+					t.Fatalf("RawIndex %d: Expected %v, got %v", i, orig.Vec3At(i), v)
+				}
 			}
 
 			n := len(sampled)
@@ -99,5 +104,4 @@ func TestVec3RandomSampleIterator(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pc/vec3slice.go
+++ b/pc/vec3slice.go
@@ -14,3 +14,7 @@ func (v Vec3Slice) Len() int {
 func (v Vec3Slice) Vec3At(i int) mat.Vec3 {
 	return v[i]
 }
+
+func (v Vec3Slice) RawIndexAt(i int) int {
+	return i
+}


### PR DESCRIPTION
Add a way to get the index of the item on the base PointCloud storage.
This allows to access the raw data (including non-standard data fields) through IndiceAccessor and RandomSampleIterator.

- Will be used in https://github.com/seqsense/pcgol/pull/60