### PR TITLE
pc/filter/voxelgrid: reduce memory usage if chunk size is larger than the cloud

### DIFF
--- a/pc/filter/voxelgrid/voxelgrid.go
+++ b/pc/filter/voxelgrid/voxelgrid.go
@@ -52,6 +52,13 @@ func (f *voxelGrid) Filter(pp *pc.PointCloud) (*pc.PointCloud, error) {
 		f.LeafSize[1] * float32(f.ChunkSize[1]),
 		f.LeafSize[2] * float32(f.ChunkSize[2]),
 	}
+	// If chunk size is larger than the original point cloud size,
+	// clamp the chunk size to avoid using excess memory
+	for i := 0; i < 3; i++ {
+		if chunkSize[i] > size[i]+f.LeafSize[i] {
+			chunkSize[i] = size[i] + f.LeafSize[i]
+		}
+	}
 	nx, ny, nz := int(size[0]/chunkSize[0])+1, int(size[1]/chunkSize[1])+1, int(size[2]/chunkSize[2])+1
 	nChunks := nx * ny * nz
 


### PR DESCRIPTION
Minor improvement of #60 

If the ChunkSize is 128x128x128 voxels and the cloud is distributed within 512x512x64 voxels, 16 chunks of 128x128x128 voxels were processed.
However, as the cloud has only 64 voxels in z direction, ChunkSize of 128x128x64 voxels is enough.